### PR TITLE
disable navigation when activeElements is Contenteditable=true for gmail

### DIFF
--- a/src/crossfire-chrome.js
+++ b/src/crossfire-chrome.js
@@ -171,7 +171,8 @@ chrome.extension.sendRequest({name: "getPreferences"},
     }
     document.addEventListener('keyup', function(e) {
       if (document.activeElement.tagName == "INPUT"
-       || document.activeElement.tagName == "TEXTAREA") {
+       || document.activeElement.tagName == "TEXTAREA"
+       || document.activeElement.contentEditable == "true" ) {
          return; // ignore
        }
        switch(e.keyCode) {
@@ -182,7 +183,8 @@ chrome.extension.sendRequest({name: "getPreferences"},
     }, false);
     document.addEventListener('keydown', function(e) {
       if (document.activeElement.tagName == "INPUT"
-       || document.activeElement.tagName == "TEXTAREA") {
+       || document.activeElement.tagName == "TEXTAREA"
+       || document.activeElement.contentEditable == "true" ) {
          return; // ignore
        }
       switch(e.keyCode) {


### PR DESCRIPTION
CrossFire for google Chrome is very helpful for Presto Opera User. i love this.

But, when Enabling this extension , Shift + Arrow Selection in "ContentEditable" dosent work .
This incident is awful for editing gmail
