### PR TITLE
Ignore keystroke if the webpage itself processed it

### DIFF
--- a/src/crossfire-chrome.js
+++ b/src/crossfire-chrome.js
@@ -184,7 +184,8 @@ chrome.extension.sendRequest({name: "getPreferences"},
     document.addEventListener('keydown', function(e) {
       if (document.activeElement.tagName == "INPUT"
        || document.activeElement.tagName == "TEXTAREA"
-       || document.activeElement.contentEditable == "true" ) {
+       || document.activeElement.contentEditable == "true"
+       || e.defaultPrevented ) {
          return; // ignore
        }
       switch(e.keyCode) {


### PR DESCRIPTION
-- Most web apps will call Event.preventDefault() if they handle a key,
which sets the Event.defaultPrevented property.
